### PR TITLE
Only parse files that may contain translations

### DIFF
--- a/src/html/angular-i18n-translations-extractor.ts
+++ b/src/html/angular-i18n-translations-extractor.ts
@@ -1,6 +1,6 @@
 import {
   AngularElement,
-  HtmlTranslationExtractionContext
+  HtmlTranslationExtractionContext,
 } from "./html-translation-extractor";
 import { Attribute } from "./element-context";
 
@@ -29,14 +29,14 @@ export default function angularI18nTranslationsExtractor(
   context: HtmlTranslationExtractionContext
 ): void {
   const i18nElementTranslation = element.attributes.find(
-    attribute => attribute.name === I18N_ATTRIBUTE_NAME
+    (attribute) => attribute.name === I18N_ATTRIBUTE_NAME
   );
 
   if (i18nElementTranslation) {
     handleTranslationsOfElements(element, context, i18nElementTranslation);
   }
 
-  const i18nAttributeTranslations = element.attributes.filter(attribute =>
+  const i18nAttributeTranslations = element.attributes.filter((attribute) =>
     I18N_ATTRIBUTE_REGEX.test(attribute.name)
   );
 
@@ -63,7 +63,7 @@ function handleTranslationsOfElements(
     context.registerTranslation({
       translationId: translationIdExtraction.translationId,
       defaultText: element.texts[0].text,
-      position: element.startPosition
+      position: element.startPosition,
     });
   } else if (element.texts.length > 1) {
     context.emitError(
@@ -72,6 +72,12 @@ function handleTranslationsOfElements(
     );
   }
 }
+
+angularI18nTranslationsExtractor.mayContainTranslations = function (
+  content: string
+): boolean {
+  return content.indexOf(I18N_ATTRIBUTE_NAME) !== -1;
+};
 
 function handleTranslationsOfAttributes(
   element: AngularElement,
@@ -101,7 +107,7 @@ function handleAttribute(
     `${I18N_ATTRIBUTE_NAME}-`.length
   );
   const attribute = element.attributes.find(
-    attribute => attribute.name === attributeName
+    (attribute) => attribute.name === attributeName
   );
 
   if (!attribute) {
@@ -129,7 +135,7 @@ function handleAttribute(
   context.registerTranslation({
     translationId: translationIdExtraction.translationId,
     defaultText: defaultText,
-    position: i18nAttribute.startPosition
+    position: i18nAttribute.startPosition,
   });
 }
 
@@ -143,19 +149,19 @@ function extractTranslationId(
       valid: false,
       error: `The attribute ${
         attribute.name
-      } on element ${context.asHtml()} attribute is missing the custom id indicator '${ID_INDICATOR}'.`
+      } on element ${context.asHtml()} attribute is missing the custom id indicator '${ID_INDICATOR}'.`,
     };
   } else if (index + ID_INDICATOR.length === attribute.value.length) {
     return {
       valid: false,
       error: `The attribute ${
         attribute.name
-      } on element ${context.asHtml()} defines an empty ID.`
+      } on element ${context.asHtml()} defines an empty ID.`,
     };
   } else {
     return {
       valid: true,
-      translationId: attribute.value.substr(index + ID_INDICATOR.length)
+      translationId: attribute.value.substr(index + ID_INDICATOR.length),
     };
   }
 }

--- a/src/html/html-translation-extractor.ts
+++ b/src/html/html-translation-extractor.ts
@@ -22,4 +22,6 @@ export interface HtmlTranslationExtractionContext {
 
 export interface HtmlTranslationExtractor {
   (element: AngularElement, context: HtmlTranslationExtractionContext): void;
+
+  mayContainTranslations?(content: string): boolean;
 }

--- a/src/html/translate-directive-translation-extractor.ts
+++ b/src/html/translate-directive-translation-extractor.ts
@@ -1,6 +1,6 @@
 import {
   HtmlTranslationExtractionContext,
-  AngularElement
+  AngularElement,
 } from "./html-translation-extractor";
 import { AngularExpressionMatch } from "./ng-filters";
 import { Attribute } from "./element-context";
@@ -15,7 +15,7 @@ export default function translateDirectiveTranslationExtractor(
   let translateDirective: boolean;
   let translationId: string;
   const translateAttribute = element.attributes.find(
-    attribute => attribute.name === "translate"
+    (attribute) => attribute.name === "translate"
   );
 
   if (element.tagName === "translate") {
@@ -35,7 +35,7 @@ export default function translateDirectiveTranslationExtractor(
     const hasTranslateAttributes = handleTranslateAttributes(element, context);
 
     const defaultTextAttribute = element.attributes.find(
-      attr => attr.name === "translate-default"
+      (attr) => attr.name === "translate-default"
     );
 
     if (!translationId) {
@@ -57,7 +57,7 @@ export default function translateDirectiveTranslationExtractor(
         defaultText: defaultTextAttribute
           ? defaultTextAttribute.value
           : undefined,
-        position: element.startPosition
+        position: element.startPosition,
       });
     } else if (!hasTranslateAttributes) {
       // no translate-attr-* and the element has not specified a translation id, someone is using the directive incorrectly
@@ -71,22 +71,25 @@ export default function translateDirectiveTranslationExtractor(
   }
 }
 
+translateDirectiveTranslationExtractor.mayContainTranslations = function (
+  content: string
+): boolean {
+  return content.indexOf("translate") !== -1;
+};
+
 type KeyedAttributes = { [name: string]: Attribute };
 
 function handleTranslateAttributes(
   element: AngularElement,
   context: HtmlTranslationExtractionContext
 ) {
-  const keyedAttributes = element.attributes.reduce(
-    (obj, attribute) => {
-      obj[attribute.name] = attribute;
-      return obj;
-    },
-    {} as KeyedAttributes
-  );
+  const keyedAttributes = element.attributes.reduce((obj, attribute) => {
+    obj[attribute.name] = attribute;
+    return obj;
+  }, {} as KeyedAttributes);
 
   // translate-attr-ATTR
-  const translateAttributes = element.attributes.filter(attr =>
+  const translateAttributes = element.attributes.filter((attr) =>
     translateAttributeRegex.test(attr.name)
   );
 
@@ -100,7 +103,7 @@ function handleTranslateAttributes(
       defaultText: defaultTextAttribute
         ? defaultTextAttribute.value
         : undefined,
-      position: attribute.startPosition
+      position: attribute.startPosition,
     });
   }
 
@@ -139,7 +142,7 @@ function handleAngularExpression(
     translationId = translationId.substring(1, translationId.length - 1);
     context.registerTranslation({
       translationId,
-      position
+      position,
     });
   }
 }


### PR DESCRIPTION
Add an optional `mayContainTranslations` function to translations
extractros which allows them to implement a heuristic
when it's worth to parse the HTML file. This should speed up
the build because cheerio will no longer have to parse
files that don't contain any translation.